### PR TITLE
master option in **sys.config**:

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ You can specifying a **queue limits** in sys.config:
 ]
 ```
 
+And create dir **/usr/local/var/lib/mx/mnesia/** with right permissions. So, mnesia data will bi in:
+```
+/usr/local/var/lib/mx/mnesia/mxnode01@127.0.0.1  %% node name
+```
+
 ## Run
 ```
 make run

--- a/conf/sys.config
+++ b/conf/sys.config
@@ -5,7 +5,7 @@
        {queue_low_threshold,  0.6},   % 60%
        {queue_high_threshold, 0.8},    % 80%
        {mnesia_base_dir,      "/usr/local/var/lib/mx/mnesia/"}
-       %, {master, "mxnode01@127.0.0.1"}
+       %, {master, "mxnode01@127.0.0.1"}  %% or "${MASTER_NODE}"
     ]},
     {lager, [
        {log_root, "/tmp/"},

--- a/src/mx_mnesia.erl
+++ b/src/mx_mnesia.erl
@@ -76,7 +76,7 @@ init([]) ->
     application:set_env(mnesia, dir, NodeDir),
 
     case application:get_env(mx, master, none) of
-        none ->
+        X when X == ""; X == none ->
             % run as master
             gen_server:cast(self(), master);
 


### PR DESCRIPTION
- add using of master option in config like env-variable (so it always will be a string). For example, we want to dynamically configure master through env variable
- some doc