### PR TITLE
optional configuration of mnesia_base_dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ run: release
 tar:
 	$(REBAR) as prod tar release -n mx
 
-demo_run:
+demo_run: compile
 	# only for demonstration purposes
 	erl -name $(node_name) -pa _build/default/lib/mx/ebin \
 		_build/default/lib/gproc/ebin \

--- a/README.md
+++ b/README.md
@@ -42,12 +42,8 @@ You can specifying a **queue limits** in sys.config:
 ]
 ```
 
-And create dir **/usr/local/var/lib/mx/mnesia/** with right permissions. So, mnesia data will be located:
-```
-/usr/local/var/lib/mx/mnesia/mxnode01@127.0.0.1  %% node name
-```
-
 ## Run
+
 ```
 make run
 ```
@@ -77,6 +73,33 @@ Call **mx:nodes()** to get the list of mx cluster nodes.
 ```erlang
 (mxnode01@127.0.0.1)2> mx:nodes().
 ['mxnode01@127.0.0.1','mxnode02@127.0.0.1']
+```
+
+## Mnesia custom directory (optional)
+
+Create dir, for example, **/usr/local/var/lib/mx/mnesia/** with correct (Read/Write) permissions.
+
+Set option `mnesia_base_dir` with this **directory** in `sys.config`:
+
+```
+    {mx, [
+       {mnesia_base_dir,      "/usr/local/var/lib/mx/mnesia/"}
+    ]},
+```
+
+Or set the value of configuration parameter `mnesia_base_dir` for **mx**:
+
+```erlang
+make demo_run node_name='mxnode01@127.0.0.1'
+
+(mxnode01@127.0.0.1)1> application:load(mx).
+(mxnode01@127.0.0.1)1> application:set_env(mx, mnesia_base_dir, "/usr/local/var/lib/mx/mnesia/").
+(mxnode01@127.0.0.1)1> application:start(mx).
+```
+
+So, mnesia data will be located:
+```
+/usr/local/var/lib/mx/mnesia/mxnode01@127.0.0.1  %% node name
 ```
 
 ## Examples

--- a/conf/sys.config
+++ b/conf/sys.config
@@ -3,8 +3,8 @@
        % queue limits
        {queue_length_limit,   100000},
        {queue_low_threshold,  0.6},   % 60%
-       {queue_high_threshold, 0.8},    % 80%
-       {mnesia_base_dir,      "/usr/local/var/lib/mx/mnesia/"}
+       {queue_high_threshold, 0.8}    % 80%
+       %, {mnesia_base_dir,      "/usr/local/var/lib/mx/mnesia/"}
        %, {master, "mxnode01@127.0.0.1"}  %% or "${MASTER_NODE}"
     ]},
     {lager, [

--- a/src/mx_mnesia.erl
+++ b/src/mx_mnesia.erl
@@ -80,13 +80,17 @@ start_link() ->
 init([]) ->
     process_flag(trap_exit, true),
 
-    {ok, MnesiaBaseDir} = application:get_env(mx, mnesia_base_dir),
-    NodeDir = MnesiaBaseDir ++ node(),
-    ok = filelib:ensure_dir(NodeDir),
-    application:set_env(mnesia, dir, NodeDir),
+    case application:get_env(mx, mnesia_base_dir, undefined) of
+        Dir when Dir == ""; Dir == undefined ->
+            pass;
+        MnesiaBaseDir when is_list(MnesiaBaseDir) ->
+            NodeDir = MnesiaBaseDir ++ node(),
+            ok = filelib:ensure_dir(NodeDir),
+            application:set_env(mnesia, dir, NodeDir)
+    end,
 
-    case application:get_env(mx, master, none) of
-        X when X == ""; X == none ->
+    case application:get_env(mx, master, undefined) of
+        X when X == ""; X == undefined ->
             run_as_master();
         Master when is_atom(Master); is_list(Master) ->
             run_as_slave(Master)


### PR DESCRIPTION
on starting mx application do not need `mnesia_base_dir` option